### PR TITLE
Expose record-to-sulv and sulv-to-record functions in the vhdl generated package

### DIFF
--- a/bin/ipxact2c
+++ b/bin/ipxact2c
@@ -31,5 +31,5 @@ if __name__ == '__main__':
 
     e = ipxactParser(args.srcFile, config)
     document = e.returnDocument()
-    generator = ipxact2otherGenerator(args.destDir)
+    generator = ipxact2otherGenerator(args.destDir, config)
     generator.generate(cAddressBlock, document)

--- a/bin/ipxact2md
+++ b/bin/ipxact2md
@@ -29,5 +29,5 @@ if __name__ == '__main__':
 
     e = ipxactParser(args.srcFile, config)
     document = e.returnDocument()
-    generator = ipxact2otherGenerator(args.destDir)
+    generator = ipxact2otherGenerator(args.destDir, config)
     generator.generate(mdAddressBlock, document)

--- a/bin/ipxact2rst
+++ b/bin/ipxact2rst
@@ -30,5 +30,5 @@ if __name__ == '__main__':
 
     e = ipxactParser(args.srcFile, config)
     document = e.returnDocument()
-    generator = ipxact2otherGenerator(args.destDir)
+    generator = ipxact2otherGenerator(args.destDir, config)
     generator.generate(rstAddressBlock, document)

--- a/bin/ipxact2systemverilog
+++ b/bin/ipxact2systemverilog
@@ -31,5 +31,5 @@ if __name__ == '__main__':
 
     e = ipxactParser(args.srcFile, config)
     document = e.returnDocument()
-    generator = ipxact2otherGenerator(args.destDir)
+    generator = ipxact2otherGenerator(args.destDir, config)
     generator.generate(systemVerilogAddressBlock, document)

--- a/bin/ipxact2vhdl
+++ b/bin/ipxact2vhdl
@@ -31,5 +31,6 @@ if __name__ == '__main__':
 
     e = ipxactParser(args.srcFile, config)
     document = e.returnDocument()
-    generator = ipxact2otherGenerator(args.destDir)
+    generator = ipxact2otherGenerator(args.destDir, config)
+    print(config)
     generator.generate(vhdlAddressBlock, document)

--- a/example/input/default.ini
+++ b/example/input/default.ini
@@ -27,3 +27,7 @@ UnusedHoles = yes
 # If yes: enums will be generated even if the register field is 1 bit width.
 OneBitEnum = no
 
+# If no:  Conversion funtions will not be made public in the VHDL package
+# If yes: Conversion funtions will be made public in the VHDL package
+VhdlPublicConvFunct = no
+

--- a/example/input/no_default.ini
+++ b/example/input/no_default.ini
@@ -1,5 +1,4 @@
 [global]
 UnusedHoles = no
 OneBitEnum = yes
-
-
+VhdlPublicConvFunct = yes

--- a/example/output_no_default/example_vhd_pkg.vhd
+++ b/example/output_no_default/example_vhd_pkg.vhd
@@ -117,6 +117,38 @@ package example_vhd_pkg is
                          registers_o : example_out_record_type
                          ) return example_out_record_type;
 
+  function reg0_record_type_to_sulv(v : reg0_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg0_record_type(v : std_ulogic_vector) return reg0_record_type;
+
+  function reg1_record_type_to_sulv(v : reg1_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg1_record_type(v : std_ulogic_vector) return reg1_record_type;
+
+  function reg2_record_type_to_sulv(v : reg2_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg2_record_type(v : std_ulogic_vector) return reg2_record_type;
+
+  function reg3_record_type_to_sulv(v : reg3_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg3_record_type(v : std_ulogic_vector) return reg3_record_type;
+
+  function reg4_record_type_to_sulv(v : reg4_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg4_record_type(v : std_ulogic_vector) return reg4_record_type;
+
+  function reg5_record_type_to_sulv(v : reg5_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg5_record_type(v : std_ulogic_vector) return reg5_record_type;
+
+  function reg6_record_type_to_sulv(v : reg6_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg6_record_type(v : std_ulogic_vector) return reg6_record_type;
+
+  function reg7_record_type_to_sulv(v : reg7_record_type) return std_ulogic_vector;
+
+  function sulv_to_reg7_record_type(v : std_ulogic_vector) return reg7_record_type;
+
 end;
 
 


### PR DESCRIPTION
For my project I need to use the sulv<->record functions outside of the generated package.
Made this a configuration. To stay compatible I needed to pass the configuration to the generator functions. If this "VhdlPublicConvFunct" configuration is made it will print the function declarations in the VHDL package.