### PR TITLE
Vermaete/readonly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ gen:
 	bin/ipxact2vhdl --srcFile example/input/test.xml --destDir example/output_no_default  --config example/input/no_default.ini
 	bin/ipxact2c --srcFile example/input/test.xml --destDir example/output_no_default  --config example/input/no_default.ini
 
+        #  test
+	bin/ipxact2systemverilog --srcFile example/input/test2.xml --destDir example/output
+	bin/ipxact2rst --srcFile example/input/test2.xml --destDir example/output
+	bin/ipxact2md --srcFile example/input/test2.xml --destDir example/output
+	bin/ipxact2vhdl --srcFile example/input/test2.xml --destDir example/output
+	bin/ipxact2md --srcFile example/input/test2.xml --destDir example/output
+	bin/ipxact2c --srcFile example/input/test2.xml --destDir example/output
+
 compile: 
 	test -d work || vlib work
 	vlog  +incdir+example/output  example/output/example_sv_pkg.sv example/tb/sv_dut.sv example/tb/tb.sv
@@ -61,6 +69,7 @@ compile_verilator:
 	verilator --cc example/output/example_sv_pkg.sv
 	verilator --cc example/output_default/example_sv_pkg.sv
 	verilator --cc example/output_no_default/example_sv_pkg.sv
+	verilator --cc example/output/example2_sv_pkg.sv
 
 compile_icarus:
 	iverilog -g2012 -o foo example/output/*.sv
@@ -86,6 +95,7 @@ clean:
 
 validate:
 	xmllint --noout --schema ipxact2systemverilog/xml/component.xsd  example/input/test.xml
+	xmllint --noout --schema ipxact2systemverilog/xml/component.xsd  example/input/test2.xml
 
 test_rst:
 	rst-lint example/output/*.rst

--- a/example/input/test2.xml
+++ b/example/input/test2.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spirit:component xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <spirit:vendor>vendor</spirit:vendor>
+   <spirit:library>library</spirit:library>
+   <spirit:name>unusedComponentName</spirit:name>
+   <spirit:version>version</spirit:version>
+   <spirit:memoryMaps>
+      <spirit:memoryMap>
+         <spirit:name>unusedMemoryMapName</spirit:name>
+         <spirit:addressBlock>
+            <spirit:name>example2</spirit:name>
+            <spirit:description>Second demo example used for the testing of the ipxact2systemverilog tool.</spirit:description>
+            <spirit:baseAddress>0</spirit:baseAddress>
+            <spirit:range>3</spirit:range>
+            <spirit:width>8</spirit:width>
+            <spirit:register>
+               <spirit:name>reg0</spirit:name>
+               <spirit:description>read something useful for reg0</spirit:description>
+               <spirit:addressOffset>0</spirit:addressOffset>
+               <spirit:size>8</spirit:size>
+               <spirit:access>read-only</spirit:access>
+               <spirit:field>
+                  <spirit:name>field0</spirit:name>
+                  <spirit:description>read something useful for field0</spirit:description>
+                  <spirit:bitOffset>0</spirit:bitOffset>
+                  <spirit:bitWidth>2</spirit:bitWidth>
+               </spirit:field>
+               <spirit:field>
+                  <spirit:name>field1</spirit:name>
+                  <spirit:description>read something useful for field1</spirit:description>
+                  <spirit:bitOffset>2</spirit:bitOffset>
+                  <spirit:bitWidth>6</spirit:bitWidth>
+               </spirit:field>
+            </spirit:register>
+
+            <spirit:register>
+               <spirit:name>reg1</spirit:name>
+               <spirit:addressOffset>1</spirit:addressOffset>
+               <spirit:size>8</spirit:size>
+               <spirit:access>read-only</spirit:access>
+               <spirit:field>
+                  <spirit:name>field0</spirit:name>
+                  <spirit:description>read something useful for field0</spirit:description>
+                  <spirit:bitOffset>0</spirit:bitOffset>
+                  <spirit:bitWidth>8</spirit:bitWidth>
+               </spirit:field>
+            </spirit:register>
+         </spirit:addressBlock>
+      </spirit:memoryMap>
+   </spirit:memoryMaps>
+</spirit:component>

--- a/example/output/example2.h
+++ b/example/output/example2.h
@@ -1,0 +1,61 @@
+#pragma once
+/* Automatically generated
+ * with the command 'bin/ipxact2c --srcFile example/input/test2.xml --destDir example/output'
+ *
+ * Do not manually edit!
+ *
+ * Example usage:
+ *     uint32_t datareg0 = read(dev, EXAMPLE_REG_ADDRESS_REG0);
+ *
+ *     uint8_t byte0 = (uint8_t)GET_EXAMPLE_REG0_BYTE0(datareg0);
+ *     uint8_t byte1 = (uint8_t)GET_EXAMPLE_REG0_BYTE1(datareg0);
+ *     uint8_t byte2 = (uint8_t)GET_EXAMPLE_REG0_BYTE2(datareg0);
+ *     uint8_t byte3 = (uint8_t)GET_EXAMPLE_REG0_BYTE3(datareg0);
+ *
+ *
+ *     uint32_t datareg7 = read(dev, EXAMPLE_REG_ADDRESS_REG7);
+ *
+ *     uint8_t nibble0 = (uint8_t)GET_EXAMPLE_REG7_NIBBLE0(datareg7);
+ *     uint8_t nibble1 = (uint8_t)GET_EXAMPLE_REG7_NIBBLE1(datareg7);
+ *     uint8_t nibble2 = (uint8_t)GET_EXAMPLE_REG7_NIBBLE2(datareg7);
+ */
+// ------------------------------------------------
+//  Register offsets
+// ------------------------------------------------
+#define EXAMPLE2_REG0_OFFSET	0x00	// read something useful for reg0
+#define EXAMPLE2_REG1_OFFSET	0x01	// 
+
+
+// ------------------------------------------------
+//  Bit operations for register reg0
+// ------------------------------------------------
+#define EXAMPLE2_REG0_FIELD0_SHIFT	0
+#define EXAMPLE2_REG0_FIELD0_MASK 	0x03
+
+#define EXAMPLE2_REG0_FIELD1_SHIFT	2
+#define EXAMPLE2_REG0_FIELD1_MASK 	0x3F
+
+// ------------------------------------------------
+//  Bit operations for register reg1
+// ------------------------------------------------
+#define EXAMPLE2_REG1_FIELD0_SHIFT	0
+#define EXAMPLE2_REG1_FIELD0_MASK 	0xFF
+
+
+// ------------------------------------------------
+//  Macro functions for register reg0
+//  - GET_EXAMPLE2_REG0_FIELD0 : read something useful for field0
+//  - GET_EXAMPLE2_REG0_FIELD1 : read something useful for field1
+// ------------------------------------------------
+
+#define GET_EXAMPLE2_REG0_FIELD0(a)	((a >> EXAMPLE2_REG0_FIELD0_SHIFT) & EXAMPLE2_REG0_FIELD0_MASK)
+#define GET_EXAMPLE2_REG0_FIELD1(a)	((a >> EXAMPLE2_REG0_FIELD1_SHIFT) & EXAMPLE2_REG0_FIELD1_MASK)
+
+// ------------------------------------------------
+//  Macro functions for register reg1
+//  - GET_EXAMPLE2_REG1_FIELD0 : read something useful for field0
+// ------------------------------------------------
+
+#define GET_EXAMPLE2_REG1_FIELD0(a)	((a >> EXAMPLE2_REG1_FIELD0_SHIFT) & EXAMPLE2_REG1_FIELD0_MASK)
+
+// End of example2.h

--- a/example/output/example2.md
+++ b/example/output/example2.md
@@ -1,0 +1,36 @@
+
+# example2
+
+
+Second demo example used for the testing of the ipxact2systemverilog tool.
+
+Base Address: 0x0
+
+
+## Registers
+
+|Address|Register Name|Description|
+| :--- | :--- | :--- |
+|0x00|[reg0](#reg0)|read something useful for reg0|
+|0x01|[reg1](#reg1)||
+
+### reg0
+  
+**Name** reg0  
+**Address** 0x0  
+**Access** read-only  
+**Description** read something useful for reg0
+|Bits|Field name|Description|
+| :--- | :--- | :--- |
+|[7:2]|field1|read something useful for field1|
+|[1:0]|field0|read something useful for field0|
+
+### reg1
+  
+**Name** reg1  
+**Address** 0x1  
+**Access** read-only  
+**Description** 
+|Bits|Field name|Description|
+| :--- | :--- | :--- |
+|[7:0]|field0|read something useful for field0|

--- a/example/output/example2.rst
+++ b/example/output/example2.rst
@@ -1,0 +1,50 @@
+========
+example2
+========
+
+Second demo example used for the testing of the ipxact2systemverilog
+tool.
+
+:Base Address: 0x0
+
+Registers
+---------
+
++-----------+-----------------+--------------------------------+
+| Address   | Register Name   | Description                    |
++===========+=================+================================+
+| 0x00      | reg0_           | read something useful for reg0 |
++-----------+-----------------+--------------------------------+
+| 0x01      | reg1_           |                                |
++-----------+-----------------+--------------------------------+
+
+reg0
+----
+
+:Name: reg0
+:Address: 0x0
+:Access: read-only
+:Description: read something useful for reg0
+
++--------+--------------+----------------------------------+
+| Bits   | Field name   | Description                      |
++========+==============+==================================+
+| [7:2]  | field1       | read something useful for field1 |
++--------+--------------+----------------------------------+
+| [1:0]  | field0       | read something useful for field0 |
++--------+--------------+----------------------------------+
+
+reg1
+----
+
+:Name: reg1
+:Address: 0x1
+:Access: read-only
+:Description:
+
++--------+--------------+----------------------------------+
+| Bits   | Field name   | Description                      |
++========+==============+==================================+
+| [7:0]  | field0       | read something useful for field0 |
++--------+--------------+----------------------------------+
+

--- a/example/output/example2_sv_pkg.sv
+++ b/example/output/example2_sv_pkg.sv
@@ -1,0 +1,73 @@
+// Automatically generated
+// with the command 'bin/ipxact2systemverilog --srcFile example/input/test2.xml --destDir example/output'
+//
+// Do not manually edit!
+//
+package example2_sv_pkg;
+
+
+const int addr_width = 2;
+const int data_width = 8;
+
+const int reg0_addr = 0;
+const int reg1_addr = 1;
+
+//synopsys translate_off
+const int example2_regAddresses [2] = '{
+     reg0_addr,
+     reg1_addr};
+
+const string example2_regNames [2] = '{
+      "reg0",
+      "reg1"};
+const reg example2_regUnResetedAddresses [2] = '{
+   1'b1,
+   1'b1};
+
+//synopsys translate_on
+
+
+
+typedef struct packed {
+   bit [5:0] field1;//bits [7:2]
+   bit [1:0] field0;//bits [1:0]
+} reg0_struct_type;
+
+
+typedef struct packed {
+   bit [7:0] field0;//bits [7:0]
+} reg1_struct_type;
+
+
+typedef struct packed {
+   reg0_struct_type reg0;
+   reg1_struct_type reg1;
+} example2_struct_type;
+
+function bit [31:0] read_example2(example2_struct_type registers,int address);
+      bit [31:0]  r;
+      case(address)
+         reg0_addr: r[$bits(registers.reg0)-1:0] = registers.reg0;
+         reg1_addr: r[$bits(registers.reg1)-1:0] = registers.reg1;
+        default: r =0;
+      endcase
+      return r;
+endfunction
+
+function example2_struct_type write_example2(bit [31:0] data, int address,
+                                             example2_struct_type registers);
+   example2_struct_type r;
+   r = registers;
+   case(address)
+         reg0_addr: r.reg0 = data[$bits(registers.reg0)-1:0];
+         reg1_addr: r.reg1 = data[$bits(registers.reg1)-1:0];
+   endcase // case address
+   return r;
+endfunction
+
+function example2_struct_type reset_example2();
+   example2_struct_type r;
+   return r;
+endfunction
+
+endpackage //example2_sv_pkg

--- a/example/output/example2_sv_pkg.svh
+++ b/example/output/example2_sv_pkg.svh
@@ -1,0 +1,3 @@
+
+`define example2_addr_width 2
+`define example2_data_width 8

--- a/example/output/example2_vhd_pkg.vhd
+++ b/example/output/example2_vhd_pkg.vhd
@@ -1,0 +1,94 @@
+--
+-- Automatically generated
+-- with the command 'bin/ipxact2vhdl --srcFile example/input/test2.xml --destDir example/output'
+--
+-- Do not manually edit!
+--
+-- VHDL 93
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package example2_vhd_pkg is
+
+  constant addr_width : natural := 2;
+  constant data_width : natural := 8;
+
+
+
+  constant reg0_addr : natural := 0 ;  -- 0x0
+  constant reg1_addr : natural := 1 ;  -- 0x1
+
+
+
+  type reg0_record_type is record
+    field1 : std_ulogic_vector(5 downto 0); -- [7:2]
+    field0 : std_ulogic_vector(1 downto 0); -- [1:0]
+  end record;
+
+  type reg1_record_type is record
+    field0 : std_ulogic_vector(7 downto 0); -- [7:0]
+  end record;
+
+  type example2_in_record_type is record
+    reg0 : reg0_record_type; -- addr 0x0
+    reg1 : reg1_record_type; -- addr 0x1
+  end record;
+
+  function read_example2(registers_i : example2_in_record_type;
+                         address : std_ulogic_vector(addr_width-1 downto 0)
+                         ) return std_ulogic_vector;
+
+end;
+
+
+package body example2_vhd_pkg is
+
+  function reg0_record_type_to_sulv(v : reg0_record_type) return std_ulogic_vector is
+    variable r : std_ulogic_vector(data_width-1 downto 0);
+  begin
+    r :=  (others => '0');
+    r(7 downto 2) := v.field1;
+    r(1 downto 0) := v.field0;
+    return r;
+  end function;
+
+  function sulv_to_reg0_record_type(v : std_ulogic_vector) return reg0_record_type is
+    variable r : reg0_record_type;
+  begin
+    r.field1 := v(7 downto 2);
+    r.field0 := v(1 downto 0);
+    return r;
+  end function;
+
+  function reg1_record_type_to_sulv(v : reg1_record_type) return std_ulogic_vector is
+    variable r : std_ulogic_vector(data_width-1 downto 0);
+  begin
+    r :=  (others => '0');
+    r(7 downto 0) := v.field0;
+    return r;
+  end function;
+
+  function sulv_to_reg1_record_type(v : std_ulogic_vector) return reg1_record_type is
+    variable r : reg1_record_type;
+  begin
+    r.field0 := v(7 downto 0);
+    return r;
+  end function;
+
+  function read_example2(registers_i : example2_in_record_type;
+                         address : std_ulogic_vector(addr_width-1 downto 0)
+                         ) return std_ulogic_vector is
+    variable r : std_ulogic_vector(data_width-1 downto 0);
+  begin
+    case to_integer(unsigned(address)) is
+      when reg0_addr => r:= reg0_record_type_to_sulv(registers_i.reg0);
+      when reg1_addr => r:= reg1_record_type_to_sulv(registers_i.reg1);
+      when others => r := (others => '0');
+    end case;
+    return r;
+  end function;
+
+end package body;


### PR DESCRIPTION
Hi Andreas,

Another fix on an issue found by @brucebenedictus,

If an IP block only has read-only registers the compilation of the VHDL code failed.
This commit removes the VHDL code for writable registers in case there are none defined.

I only did this for VHDL.  But tested the systemverilog code with the verilator step in the Makefile.
I have no other licenses to test this on verilog.
If this an issue for the merge?

No need yet for a new release.  My generation of a document with Wavedrom Bitfield images added and Sphinx is soon ready to be merged.

Br